### PR TITLE
Cleanup log for duplicate entries

### DIFF
--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -403,6 +403,16 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
                $log                     = new PluginManufacturersimportsLog();
                $log->add($values);
 
+               // cleanup Log
+               $log_clean               = new PluginManufacturersimportsLog();
+               $log_clean->deleteByCriteria(array(
+                       'items_id' => $ID,
+                       'itemtype' => $type,
+                       'import_status' => 2,
+                       'LIMIT' => 1
+                   )
+               );
+
                $_SESSION["glpi_plugin_manufacturersimports_total"]+=1;
 
          } else { // Failed check contents


### PR DESCRIPTION
In 1.8.0
Some materials can have duplicate entries in glpi_plugin_manufacturersimports_logs with import_status with value in 1 and 2, then this materials appear in not import and imported list