### PR TITLE
Release of updated version for HP using apikey and apisecret 

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -75,6 +75,8 @@ function plugin_manufacturersimports_install() {
 
    } else if (!$DB->fieldExists("glpi_plugin_manufacturersimports_configs", "supplier_key")) {
       $DB->runFile($sql_root . "/update-1.7.0.sql");
+   } else if (!$DB->fieldExists("glpi_plugin_manufacturersimports_configs", "supplier_secret")) {
+      $DB->runFile($sql_root . "/update-2.0.2.sql");
    }
 
    $query = "UPDATE `glpi_plugin_manufacturersimports_configs` 

--- a/hook.php
+++ b/hook.php
@@ -33,7 +33,7 @@ function plugin_manufacturersimports_install() {
    include_once(GLPI_ROOT . "/plugins/manufacturersimports/inc/profile.class.php");
    include_once(GLPI_ROOT . "/plugins/manufacturersimports/inc/config.class.php");
 
-   $migration = new Migration("2.0.1");
+   $migration = new Migration("2.0.2");
    $update    = false;
 
    //Root of SQL files for DB installation or upgrade
@@ -41,7 +41,7 @@ function plugin_manufacturersimports_install() {
 
    if (!$DB->tableExists("glpi_plugin_manufacturersimports_configs")) {
 
-      $DB->runFile($sql_root . "/empty-2.0.1.sql");
+      $DB->runFile($sql_root . "/empty-2.0.2.sql");
 
    } else if ($DB->tableExists("glpi_plugin_suppliertag_config")
               && !$DB->fieldExists("glpi_plugin_suppliertag_config", "FK_entities")) {
@@ -98,7 +98,7 @@ function plugin_manufacturersimports_install() {
    $DB->query($query);
 
    $query = "UPDATE `glpi_plugin_manufacturersimports_configs` 
-             SET `Supplier_url` = 'http://h20565.www2.hpe.com/hpsc/wc/public/find' 
+             SET `Supplier_url` = 'https://css.api.hp.com/oauth/v1/token' 
              WHERE `name` ='" . PluginManufacturersimportsConfig::HP . "'";
    $DB->query($query);
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -106,11 +106,10 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
                $this->fields["supplier_key"] = "123456789";
             }
             if ($type == self::HP) {
-			   $apiKey = '123456789990900AAAAAA';
-			   $apiSecret = 'abcdefabcdefAaBBBBB';
+               $apiKey = '123456789990900AAAAAA';
+               $apiSecret = 'abcdefabcdefAaBBBBB';
                $this->fields["supplier_key"] = $apiKey;
                $this->fields["supplier_secret"] = $apiSecret;
-			   $this->fields["supplier_url"] = "https://css.api.hp.com/oauth/v1/token";
             }
             break;
          default:

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -105,6 +105,14 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
             if ($type == self::DELL) {
                $this->fields["supplier_key"] = "123456789";
             }
+			/* MODIF HP */
+            if ($type == self::HP) {
+			   $apiKey = '123456789990900AAAAAA';
+			   $apiSecret = 'abcdefabcdefAaBBBBB';
+               $this->fields["supplier_key"] = $apiKey;
+               $this->fields["supplier_secret"] = $apiSecret;
+            }
+			/* FIN MODIF */
             break;
          default:
             $this->post_getEmpty();
@@ -342,6 +350,21 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
       } else {
          echo "<input type='hidden' name='warranty_duration' value='0'>\n";
       }
+	// MODIF HP
+      if ($this->fields["name"] == self::HP) {
+         echo "<tr>";
+         echo "<td class='tab_bg_2 center' colspan='2'>".__('Manufacturer API key', 'manufacturersimports')."</td>";
+         echo "<td class='tab_bg_2 left' colspan='2'>";
+         echo "<input type='text' name='supplier_key' size='32' value='".$this->fields["supplier_key"]."'>";
+         echo "</td>";
+         echo "</tr>";
+         echo "<tr>";
+         echo "<td class='tab_bg_2 center' colspan='2'>".__('Manufacturer API Secret', 'manufacturersimports')."</td>";
+         echo "<td class='tab_bg_2 left' colspan='2'>";
+         echo "<input type='text' name='supplier_secret' size='32' value='".$this->fields["supplier_secret"]."'>";
+         echo "</td>";
+         echo "</tr>";
+	  } else    /* FIN MODIF HP */
       if ($this->fields["name"] != self::DELL) {
          echo "<tr>";
          echo "<td class='tab_bg_2 center' colspan='2'>".__('Auto add of document', 'manufacturersimports')."</td>";

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -110,6 +110,7 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
 			   $apiSecret = 'abcdefabcdefAaBBBBB';
                $this->fields["supplier_key"] = $apiKey;
                $this->fields["supplier_secret"] = $apiSecret;
+			   $this->fields["supplier_url"] = "https://css.api.hp.com/oauth/v1/token";
             }
             break;
          default:

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -105,14 +105,12 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
             if ($type == self::DELL) {
                $this->fields["supplier_key"] = "123456789";
             }
-			/* MODIF HP */
             if ($type == self::HP) {
 			   $apiKey = '123456789990900AAAAAA';
 			   $apiSecret = 'abcdefabcdefAaBBBBB';
                $this->fields["supplier_key"] = $apiKey;
                $this->fields["supplier_secret"] = $apiSecret;
             }
-			/* FIN MODIF */
             break;
          default:
             $this->post_getEmpty();
@@ -350,21 +348,21 @@ class PluginManufacturersimportsConfig extends CommonDBTM {
       } else {
          echo "<input type='hidden' name='warranty_duration' value='0'>\n";
       }
-	// MODIF HP
+
       if ($this->fields["name"] == self::HP) {
          echo "<tr>";
          echo "<td class='tab_bg_2 center' colspan='2'>".__('Manufacturer API key', 'manufacturersimports')."</td>";
          echo "<td class='tab_bg_2 left' colspan='2'>";
-         echo "<input type='text' name='supplier_key' size='32' value='".$this->fields["supplier_key"]."'>";
+         echo "<input type='text' name='supplier_key' size='100' value='".$this->fields["supplier_key"]."'>";
          echo "</td>";
          echo "</tr>";
          echo "<tr>";
          echo "<td class='tab_bg_2 center' colspan='2'>".__('Manufacturer API Secret', 'manufacturersimports')."</td>";
          echo "<td class='tab_bg_2 left' colspan='2'>";
-         echo "<input type='text' name='supplier_secret' size='32' value='".$this->fields["supplier_secret"]."'>";
+         echo "<input type='text' name='supplier_secret' size='100' value='".$this->fields["supplier_secret"]."'>";
          echo "</td>";
          echo "</tr>";
-	  } else    /* FIN MODIF HP */
+	  } else
       if ($this->fields["name"] != self::DELL) {
          echo "<tr>";
          echo "<td class='tab_bg_2 center' colspan='2'>".__('Auto add of document', 'manufacturersimports')."</td>";

--- a/inc/hp.class.php
+++ b/inc/hp.class.php
@@ -44,7 +44,6 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
    }
 
    function getSearchField() {
-      // return "Start date";
 	  return false;	// Do nothing: So, that all the content is returned 
    }
 
@@ -53,15 +52,12 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
     */
    function getSupplierInfo($compSerial = null, $otherSerial = null, $key = null, $supplierUrl = null, $secret = null) {
       $info["name"]          = PluginManufacturersimportsConfig::HP;
-	  $info["supplier_url "] = "https://css.api.hp.com";
+      $info["supplier_url "] = "https://css.api.hp.com";
       if (empty($otherSerial)) {
-
 		$info["url"] = $supplierUrl;
       } else {
-
-
-       $info["url"] = $supplierUrl;
-		$info['post']['pn'] = $otherSerial;
+        $info["url"] = $supplierUrl;
+        $info['post']['pn'] = $otherSerial;
 	  }
 
 	  $info['post'] = [ 'apiKey' => $key, 
@@ -78,59 +74,59 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
     * @see PluginManufacturersimportsManufacturer::getBuyDate()
     */
    function getBuyDate($contents) {
-$exp = explode(',', $contents);
-		foreach( $exp as $e => $val) {
-			$elt = explode(':', $val);
-			if( in_array('"startDate"', $elt)) {		// BuyDate is identical to startDate
-				$startDate = str_replace('"','', $elt[1]);
-				return $startDate; // BuyDate found
-			}
-		}
-		return false;	// BuyDate not found!!!
+      $exp = explode(',', $contents);
+      foreach( $exp as $e => $val) {
+         $elt = explode(':', $val);
+         if( in_array('"startDate"', $elt)) {		// BuyDate is identical to startDate
+            $startDate = str_replace('"','', $elt[1]);
+            return $startDate; // BuyDate found
+         }
+      }
+      return false;
    }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getStartDate()
     */
    function getStartDate($contents) {
-$exp = explode(',', $contents);
-		foreach( $exp as $e => $val) {
-			$elt = explode(':', $val);
-			if( in_array('"startDate"', $elt)) {
-				$startDate = str_replace('"','', $elt[1]);
-				return $startDate; // StartDate found
-			}
-		}
-		return false;	// StartDate not found!!!
+      $exp = explode(',', $contents);
+      foreach( $exp as $e => $val) {
+         $elt = explode(':', $val);
+         if( in_array('"startDate"', $elt)) {
+            $startDate = str_replace('"','', $elt[1]);
+            return $startDate; // StartDate found
+         }
+      }
+      return false;
    }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getExpirationDate()
     */
    function getExpirationDate($contents) {
-		$exp = explode(',', $contents);
-		foreach( $exp as $e => $val) {
-			$elt = explode(':', $val);
-			if( in_array('"endDate"', $elt)) {
-				$endDate = str_replace('"','', $elt[1]);
-				return $endDate; // EndDate found
-			}
-		}
-		return false;	// EndDate not found!!!  
+      $exp = explode(',', $contents);
+      foreach( $exp as $e => $val) {
+         $elt = explode(':', $val);
+         if( in_array('"endDate"', $elt)) {
+            $endDate = str_replace('"','', $elt[1]);
+            return $endDate; // EndDate found
+         }
+      }
+      return false;	  
 	}
-/* NEW method: */   
+
    /**
     * @see PluginManufacturersimportsManufacturer::getWarrantyInfo()
     */
    function getWarrantyInfo($contents) {
       $exp = explode(',', $contents);
-		foreach( $exp as $e => $val) {
-			$elt = explode(':', $val);
-			if( in_array('"status"', $elt)) {
-				$warrantyInfo = str_replace('"','', $elt[1]);
-				return $warrantyInfo; // warrantyInfo found
-			}
-		}
-		return false;	// Warranty Info not found!!!
+      foreach( $exp as $e => $val) {
+         $elt = explode(':', $val);
+         if( in_array('"status"', $elt)) {
+           $warrantyInfo = str_replace('"','', $elt[1]);
+           return $warrantyInfo; // warrantyInfo found
+         }
+      }
+      return false;
    }
 }

--- a/inc/hp.class.php
+++ b/inc/hp.class.php
@@ -52,7 +52,7 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
     */
    function getSupplierInfo($compSerial = null, $otherSerial = null, $key = null, $supplierUrl = null, $secret = null) {
       $info["name"]          = PluginManufacturersimportsConfig::HP;
-      $info["supplier_url "] = "https://css.api.hp.com";
+      $info["supplier_url"] = "https://css.api.hp.com/oauth/v1/token";
       if (empty($otherSerial)) {
 		$info["url"] = $supplierUrl;
       } else {

--- a/inc/hp.class.php
+++ b/inc/hp.class.php
@@ -44,21 +44,33 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
    }
 
    function getSearchField() {
-      return "Start date";
+      // return "Start date";
+	  return false;	// Do nothing: So, that all the content is returned 
    }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getSupplierInfo()
     */
-   function getSupplierInfo($compSerial = null, $otherSerial = null, $key = null, $supplierUrl = null) {
+   function getSupplierInfo($compSerial = null, $otherSerial = null, $key = null, $supplierUrl = null, $secret = null) {
       $info["name"]          = PluginManufacturersimportsConfig::HP;
-      $info["supplier_url"] = "http://h20565.www2.hpe.com/hpsc/wc/public/find";
-
+	  $info["supplier_url "] = "https://css.api.hp.com";
       if (empty($otherSerial)) {
-         $info["url"] = $supplierUrl."?rows[0].item.countryCode=FR&rows[0].item.serialNumber=$compSerial&submitButton=Envoyer";
+
+		$info["url"] = $supplierUrl;
       } else {
-         $info["url"] = $supplierUrl."?rows[0].item.countryCode=FR&rows[0].item.serialNumber=$compSerial&submitButton=Envoyer&rows[0].item.productNumber=$otherSerial";
-      }
+
+
+       $info["url"] = $supplierUrl;
+		$info['post']['pn'] = $otherSerial;
+	  }
+
+	  $info['post'] = [ 'apiKey' => $key, 
+		'apiSecret' => $secret, 
+		'grantType' => 'client_credentials', 
+		'scope'     => 'warranty',
+		'sn'        => $compSerial,
+	  ];
+	  
       return $info;
    }
 
@@ -66,121 +78,59 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
     * @see PluginManufacturersimportsManufacturer::getBuyDate()
     */
    function getBuyDate($contents) {
-      $matchesarray = [];
-      preg_match_all("/([A-Z][a-z][a-z] \d\d?, \d{4})/", $contents, $matchesarray);
-
-      $datetimestamp = date('U');
-      Toolbox::logDebug($matchesarray);
-      if (isset($matchesarray[0][0])) {
-         $myDate = $matchesarray[0][0];
-         $myDate = str_replace(' ', '-', $myDate);
-         $myDate = str_replace(',', '', $myDate);
-         $myDate = str_replace('Jan', '01', $myDate);
-         $myDate = str_replace('Feb', '02', $myDate);
-         $myDate = str_replace('Mar', '03', $myDate);
-         $myDate = str_replace('Apr', '04', $myDate);
-         $myDate = str_replace('May', '05', $myDate);
-         $myDate = str_replace('Jun', '06', $myDate);
-         $myDate = str_replace('Jul', '07', $myDate);
-         $myDate = str_replace('Aug', '08', $myDate);
-         $myDate = str_replace('Sep', '09', $myDate);
-         $myDate = str_replace('Oct', '10', $myDate);
-         $myDate = str_replace('Nov', '11', $myDate);
-         $myDate = str_replace('Dec', '12', $myDate);
-
-         list($month, $day, $year) = explode('-', $myDate);
-         $myDate = date("U", mktime(0, 0, 0, $month, $day, $year));
-         if ($myDate < $datetimestamp) {
-            $datetimestamp = $myDate;
-         }
-
-         $myDate = date("Y-m-d", $datetimestamp);
-
-         return $myDate;
-      } else {
-         return false;
-      }
+$exp = explode(',', $contents);
+		foreach( $exp as $e => $val) {
+			$elt = explode(':', $val);
+			if( in_array('"startDate"', $elt)) {		// BuyDate is identical to startDate
+				$startDate = str_replace('"','', $elt[1]);
+				return $startDate; // BuyDate found
+			}
+		}
+		return false;	// BuyDate not found!!!
    }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getStartDate()
     */
    function getStartDate($contents) {
-
-      $matchesarray = [];
-      preg_match_all("/([A-Z][a-z][a-z] \d\d?, \d{4})/", $contents, $matchesarray);
-
-      $datetimestamp = date('U');
-
-      $index = count($matchesarray[0])-2;
-      if (isset($matchesarray[0][$index])) {
-         $myDate = $matchesarray[0][$index];
-         $myDate = str_replace(' ', '-', $myDate);
-         $myDate = str_replace(',', '', $myDate);
-         $myDate = str_replace('Jan', '01', $myDate);
-         $myDate = str_replace('Feb', '02', $myDate);
-         $myDate = str_replace('Mar', '03', $myDate);
-         $myDate = str_replace('Apr', '04', $myDate);
-         $myDate = str_replace('May', '05', $myDate);
-         $myDate = str_replace('Jun', '06', $myDate);
-         $myDate = str_replace('Jul', '07', $myDate);
-         $myDate = str_replace('Aug', '08', $myDate);
-         $myDate = str_replace('Sep', '09', $myDate);
-         $myDate = str_replace('Oct', '10', $myDate);
-         $myDate = str_replace('Nov', '11', $myDate);
-         $myDate = str_replace('Dec', '12', $myDate);
-
-         list($month, $day, $year) = explode('-', $myDate);
-         $myDate = date("U", mktime(0, 0, 0, $month, $day, $year));
-         if ($myDate < $datetimestamp) {
-            $datetimestamp = $myDate;
-         }
-         $myDate = date("Y-m-d", $datetimestamp);
-
-         return $myDate;
-      } else {
-         return false;
-      }
-
+$exp = explode(',', $contents);
+		foreach( $exp as $e => $val) {
+			$elt = explode(':', $val);
+			if( in_array('"startDate"', $elt)) {
+				$startDate = str_replace('"','', $elt[1]);
+				return $startDate; // StartDate found
+			}
+		}
+		return false;	// StartDate not found!!!
    }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getExpirationDate()
     */
    function getExpirationDate($contents) {
-
-      preg_match_all("/([A-Z][a-z][a-z] \d\d?, \d{4})/", $contents, $matchesarray);
-
-      if (isset($matchesarray[0])) {
-         $date = date("Y-m-d", strtotime(0));
-
-         foreach ($matchesarray[0] as $myDate) {
-            $myEndDate = str_replace(' ', '-', $myDate);
-            $myEndDate = str_replace(',', '', $myEndDate);
-            $myEndDate = str_replace('Jan', '01', $myEndDate);
-            $myEndDate = str_replace('Feb', '02', $myEndDate);
-            $myEndDate = str_replace('Mar', '03', $myEndDate);
-            $myEndDate = str_replace('Apr', '04', $myEndDate);
-            $myEndDate = str_replace('May', '05', $myEndDate);
-            $myEndDate = str_replace('Jun', '06', $myEndDate);
-            $myEndDate = str_replace('Jul', '07', $myEndDate);
-            $myEndDate = str_replace('Aug', '08', $myEndDate);
-            $myEndDate = str_replace('Sep', '09', $myEndDate);
-            $myEndDate = str_replace('Oct', '10', $myEndDate);
-            $myEndDate = str_replace('Nov', '11', $myEndDate);
-            $myEndDate = str_replace('Dec', '12', $myEndDate);
-
-            list($month, $day, $year) = explode('-', $myEndDate);
-            $myEndDate = $year."-".$month."-".$day;
-
-            if (strtotime($myEndDate) > strtotime($date)) {
-               $date = $myEndDate;
-            }
-         }
-
-         return $date;
-      } else {
-         return false;
-      }
+		$exp = explode(',', $contents);
+		foreach( $exp as $e => $val) {
+			$elt = explode(':', $val);
+			if( in_array('"endDate"', $elt)) {
+				$endDate = str_replace('"','', $elt[1]);
+				return $endDate; // EndDate found
+			}
+		}
+		return false;	// EndDate not found!!!  
+	}
+/* NEW method: */   
+   /**
+    * @see PluginManufacturersimportsManufacturer::getWarrantyInfo()
+    */
+   function getWarrantyInfo($contents) {
+      $exp = explode(',', $contents);
+		foreach( $exp as $e => $val) {
+			$elt = explode(':', $val);
+			if( in_array('"status"', $elt)) {
+				$warrantyInfo = str_replace('"','', $elt[1]);
+				return $warrantyInfo; // warrantyInfo found
+			}
+		}
+		return false;	// Warranty Info not found!!!
    }
 }

--- a/inc/hp.class.php
+++ b/inc/hp.class.php
@@ -60,13 +60,13 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
         $info['post']['pn'] = $otherSerial;
 	  }
 
-	  $info['post'] = [ 'apiKey' => $key, 
-		'apiSecret' => $secret, 
-		'grantType' => 'client_credentials', 
-		'scope'     => 'warranty',
-		'sn'        => $compSerial,
-	  ];
-	  
+      $info['post'] = [ 'apiKey' => $key, 
+         'apiSecret' => $secret, 
+         'grantType' => 'client_credentials', 
+         'scope'     => 'warranty',
+         'sn'        => $compSerial,
+      ];
+
       return $info;
    }
 

--- a/inc/hp.class.php
+++ b/inc/hp.class.php
@@ -44,7 +44,7 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
    }
 
    function getSearchField() {
-	  return false;	// Do nothing: So, that all the content is returned 
+      return false;	// Do nothing: So, that all the content is returned 
    }
 
    /**
@@ -54,11 +54,11 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
       $info["name"]          = PluginManufacturersimportsConfig::HP;
       $info["supplier_url"] = "https://css.api.hp.com/oauth/v1/token";
       if (empty($otherSerial)) {
-		$info["url"] = $supplierUrl;
+        $info["url"] = $supplierUrl;
       } else {
         $info["url"] = $supplierUrl;
         $info['post']['pn'] = $otherSerial;
-	  }
+      }
 
       $info['post'] = [ 'apiKey' => $key, 
          'apiSecret' => $secret, 
@@ -113,7 +113,7 @@ class PluginManufacturersimportsHP extends PluginManufacturersimportsManufacture
          }
       }
       return false;	  
-	}
+   }
 
    /**
     * @see PluginManufacturersimportsManufacturer::getWarrantyInfo()

--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -112,12 +112,12 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
          curl_setopt($ch, CURLOPT_POSTREDIR, 2);
          curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
 
-		// ADDED FOR HP curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
-		if( $options['suppliername'] == PluginManufacturersimportsConfig::HP) {
+        // ADDED FOR HP curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
+        if( $options['suppliername'] == PluginManufacturersimportsConfig::HP) {
           curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
-          $token = $options["token"];
 
-          if( $token != '') {
+          if( isset( $options["token"])) {
+            $token = $options["token"];
             /*		Example: $postHP = '[{"sn": "CND3210W9M","pn": "D5H49AV"}]'; */
             $postHP = '[{';
             foreach( $options['post'] as $key => $value)

--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -114,26 +114,25 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
 
 		// ADDED FOR HP curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
 		if( $options['suppliername'] == PluginManufacturersimportsConfig::HP) {
-			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
-			$token = $options["token"];
-			
-			if( $token != '') {
-				/*		Example: $postHP = '[{"sn": "CND3210W9M","pn": "D5H49AV"}]'; */
-				$postHP = '[{';
-				foreach( $options['post'] as $key => $value)
-					$postHP.= '"'.$key.'": "'.$value.'",';
-				$postHP.='}]';
-				$postHP = str_replace(',}]', '}]', $postHP);
-				
-			//	echo "<br>POST HP:". $postHP."<br>";
-				curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-				   'Accept: application/json',
-				   'Content-Type: application/json',
-				   'Authorization: Bearer ' . $token
-				   ));
-				curl_setopt($ch, CURLOPT_POSTFIELDS, $postHP);
-			}
-		  } /* END MODIF */
+          curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
+          $token = $options["token"];
+
+          if( $token != '') {
+            /*		Example: $postHP = '[{"sn": "CND3210W9M","pn": "D5H49AV"}]'; */
+            $postHP = '[{';
+            foreach( $options['post'] as $key => $value)
+               $postHP.= '"'.$key.'": "'.$value.'",';
+            $postHP.='}]';
+            $postHP = str_replace(',}]', '}]', $postHP);
+
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+               'Accept: application/json',
+               'Content-Type: application/json',
+               'Authorization: Bearer ' . $token
+            ));
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $postHP);
+          }
+		}
       }
 
       if (!$options["download"]) {
@@ -369,7 +368,7 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
       $suppliername = $config->fields["name"];
       $supplierUrl  = $config->fields["supplier_url"];
       $supplierkey  = $config->fields["supplier_key"];
-	  $supplierSecret  = $config->fields["supplier_secret"];
+      $supplierSecret  = $config->fields["supplier_secret"];
       $itemtable = getTableForItemType($type);
 
       $query  = "SELECT `" . $itemtable . "`.`id`,
@@ -402,7 +401,7 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
          echo "<a href='" . $link . "?id=" . $ID . "'>" . $line["name"] . $dID . "</a><br>" . $otherSerial . "</td>";
 
          $url  = PluginManufacturersimportsPreImport::selectSupplier($suppliername, $supplierUrl, $compSerial, $otherSerial, $supplierkey, $supplierSecret);
-         $post = PluginManufacturersimportsPreImport::getSupplierPost($suppliername, $compSerial, $otherSerial, $supplierkey, $supplierSecret); // HP ADD key,secret
+         $post = PluginManufacturersimportsPreImport::getSupplierPost($suppliername, $compSerial, $otherSerial, $supplierkey, $supplierSecret);
 
          //On complete l url du support du fournisseur avec le serial
          echo "<td>" . $compSerial . "</td>";

--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -479,23 +479,22 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
                        "suppliername" => $suppliername];
 
       $contents    = self::cURLData($options);
-	// MODIF HP
-	  if( $suppliername == PluginManufacturersimportsConfig::HP){
-		$json   = json_decode($contents);
-		$token = $json->access_token;
-	
-		$url = 'https://css.api.hp.com/productWarranty/v1/queries';  // Second Curl to get the Warranty data passing $token
-		
-		$options2 = array("url"          => $url,
+      if( $suppliername == PluginManufacturersimportsConfig::HP){
+        $json   = json_decode($contents);
+        $token = $json->access_token;
+
+        $url = 'https://css.api.hp.com/productWarranty/v1/queries';  // Second Curl to get the Warranty data passing $token
+
+        $options2 = array("url"          => $url,
                        "download"     => false,
                        "file"         => false,
                        "post"         => $post,
                        "suppliername" => $suppliername,
-					   "token"		  => $token);	// Passing Token
-		$contents    = self::cURLData($options2);	// Getting Warranty Data
-	  }
-	
-	  $allcontents = $contents;
+                       "token"        => $token); // Passing Token
+        $contents    = self::cURLData($options2); // Getting Warranty Data
+      }
+
+      $allcontents = $contents;
       // On extrait la date de garantie de la variable contents.
       $field = self::selectSupplierfield($suppliername);
 

--- a/inc/preimport.class.php
+++ b/inc/preimport.class.php
@@ -160,7 +160,7 @@ class PluginManufacturersimportsPreImport extends CommonDBTM {
     *
     * @return string
     */
-   static function getSupplierPost($suppliername, $compSerial, $otherserial = null, $supplierKey = null, $supplierSecret = null) {
+   static function getSupplierPost($suppliername, $compSerial, $otherserial = null, $supplierKey = null, $supplierSecret = null, $supplierUrl = null) {
 
       $post = "";
       if (!empty($suppliername)) {

--- a/inc/preimport.class.php
+++ b/inc/preimport.class.php
@@ -162,7 +162,7 @@ class PluginManufacturersimportsPreImport extends CommonDBTM {
       if (!empty($suppliername)) {
          $supplierclass = "PluginManufacturersimports" . $suppliername;
          $supplier      = new $supplierclass();
-         $infos         = $supplier->getSupplierInfo($compSerial, $otherserial);
+         $infos         = $supplier->getSupplierInfo($compSerial, $otherserial, $supplierKey, $supplierUrl, $supplierSecret);
          if (isset($infos['post'])) {
             $post = $infos['post'];
          }

--- a/inc/preimport.class.php
+++ b/inc/preimport.class.php
@@ -88,17 +88,19 @@ class PluginManufacturersimportsPreImport extends CommonDBTM {
     * @param $supplierUrl the supplierUrl (in plugin config)
     * @param $compSerial the serial of the device
     * @param $otherSerial the otherSerial (model) of the device
+    * @param null $supplierkey the supplierkey 
+    * @param null $supplierSecret the supplierSecret
     *
     * @return $url of the supplier
     *
     */
-   static function selectSupplier($suppliername, $supplierUrl, $compSerial, $otherserial = null, $supplierkey = null) {
+   static function selectSupplier($suppliername, $supplierUrl, $compSerial, $otherserial = null, $supplierkey = null, $supplierSecret = null) {
 
       $url = "";
       if (!empty($suppliername)) {
          $supplierclass = "PluginManufacturersimports" . $suppliername;
          $supplier      = new $supplierclass();
-         $infos         = $supplier->getSupplierInfo($compSerial, $otherserial, $supplierkey, $supplierUrl);
+         $infos         = $supplier->getSupplierInfo($compSerial, $otherserial, $supplierkey, $supplierUrl, $supplierSecret);
          $url           = $infos['url'];
       }
       //toolbox::logdebug($url);
@@ -153,10 +155,12 @@ class PluginManufacturersimportsPreImport extends CommonDBTM {
     * @param      $suppliername
     * @param      $compSerial
     * @param null $otherserial
+    * @param null $supplierKey the supplierkey 
+    * @param null $supplierSecret the supplierSecret
     *
     * @return string
     */
-   static function getSupplierPost($suppliername, $compSerial, $otherserial = null) {
+   static function getSupplierPost($suppliername, $compSerial, $otherserial = null, $supplierKey = null, $supplierSecret = null) {
 
       $post = "";
       if (!empty($suppliername)) {

--- a/sql/empty-2.0.2.sql
+++ b/sql/empty-2.0.2.sql
@@ -1,0 +1,48 @@
+DROP TABLE IF EXISTS `glpi_plugin_manufacturersimports_configs`;
+CREATE TABLE `glpi_plugin_manufacturersimports_configs` (
+   `id` int(11) NOT NULL auto_increment,
+   `name` varchar(255) collate utf8_unicode_ci default NULL,
+   `entities_id` int(11) NOT NULL default '0',
+   `is_recursive` tinyint(1) NOT NULL default '0',
+   `supplier_url` varchar(255) collate utf8_unicode_ci collate utf8_unicode_ci default NULL,
+   `manufacturers_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_manufacturers (id)',
+   `suppliers_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_suppliers (id)',
+   `warranty_duration` int(11) NOT NULL default '0',
+   `document_adding` int(11) NOT NULL default '0',
+   `documentcategories_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_documentcategories (id)',
+   `comment_adding` int(11) NOT NULL default '0',
+   `supplier_key` VARCHAR(255) default NULL,
+   `supplier_secret` VARCHAR(255) NOT NULL,
+   PRIMARY KEY  (`id`),
+   KEY `name` (`name`),
+   KEY `entities_id` (`entities_id`),
+   KEY `manufacturers_id` (`manufacturers_id`),
+   KEY `suppliers_id` (`suppliers_id`),
+   KEY `documentcategories_id` (`documentcategories_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+DROP TABLE IF EXISTS `glpi_plugin_manufacturersimports_models`;
+CREATE TABLE `glpi_plugin_manufacturersimports_models` (
+   `id` int(11) NOT NULL auto_increment,
+   `model_name` varchar(100) collate utf8_unicode_ci default NULL,
+   `items_id` int(11) NOT NULL default '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
+   `itemtype` varchar(100) collate utf8_unicode_ci NOT NULL COMMENT 'see .class.php file',
+   PRIMARY KEY  (`id`),
+   UNIQUE KEY `unicity` (`model_name`,`items_id`,`itemtype`),
+   KEY `FK_device` (`items_id`,`itemtype`),
+   KEY `item` (`itemtype`,`items_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+DROP TABLE IF EXISTS `glpi_plugin_manufacturersimports_logs`;
+CREATE TABLE `glpi_plugin_manufacturersimports_logs` (
+   `id` int(11) NOT NULL auto_increment,
+   `import_status` int(11) NOT NULL default '0',
+   `items_id` int(11) NOT NULL default '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
+   `itemtype` varchar(100) collate utf8_unicode_ci NOT NULL COMMENT 'see .class.php file',
+   `documents_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_documents (id)',
+   `date_import` DATE default NULL,
+   PRIMARY KEY  (`id`),
+   UNIQUE KEY `unicity` (`import_status`,`items_id`,`itemtype`),
+  KEY `FK_device` (`items_id`,`itemtype`),
+  KEY `item` (`itemtype`,`items_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/sql/update-2.0.2.sql
+++ b/sql/update-2.0.2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `glpi_plugin_manufacturersimports_configs` ADD `supplier_secret` VARCHAR(255) NOT NULL ;


### PR DESCRIPTION
Release of first version of the Updated HP plugin. 
This version uses the ApiKey and ApiSecret that can be obtained creating an account on the hp warranty api website: https://developers.hp.com/css-enroll
After enrollment process, one should wait for an approval from HP for getting the access and create an APP that will provide you a key/secret pair.

The account provides the access to 100 requests/day. WIth the possibility to ask HP to upgrade the account to more than 100/day.

