### PR TITLE
Fix Lenovo import URL

### DIFF
--- a/inc/lenovo.class.php
+++ b/inc/lenovo.class.php
@@ -83,8 +83,8 @@ class PluginManufacturersimportsLenovo extends PluginManufacturersimportsManufac
                             $supplierUrl = null) {
 
       $info["name"]         = PluginManufacturersimportsConfig::LENOVO;
-      $info["supplier_url"] = "https://www.lenovo.com/us/en/warranty/";
-      $info["url"]          = $supplierUrl . $compSerial."?machineType=&btnSubmit";
+      $info["supplier_url"] = "https://www.lenovo.com/us/en/warrantyApos?serialNumber=";
+      $info["url"]          = $supplierUrl . $compSerial;
       return $info;
    }
 

--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -496,6 +496,17 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
          }
       }
 
+      if ($suppliername == PluginManufacturersimportsConfig::LENOVO && $contents != null) {
+         $lines = explode("\n", $contents);
+         foreach($lines as $line){
+            if(preg_match("/var tempJSON = /", $line)){
+               $line = preg_replace("/\s+var tempJSON = /", "", $line);
+               $contents = substr($line, 0, -1);
+               break;
+            }
+         }
+      }
+
       $allcontents = $contents;
 
       // On extrait la date de garantie de la variable contents.


### PR DESCRIPTION
Fix issue #68 

After research, LENOVO has provided APIs for querying.
http://supportapi.lenovo.com/Documentation/

But I unable to apply for the official Client ID.

Finally, I get JSON from warranty query page.
https://www.lenovo.com/us/en/warrantyApos?serialNumber=[SN]