### PR TITLE
Fix issue with removed decrypt function

### DIFF
--- a/inc/postimport.class.php
+++ b/inc/postimport.class.php
@@ -76,7 +76,7 @@ class PluginManufacturersimportsPostImport extends CommonDBTM {
       $timeout     = 30;
       $proxy_host  = !empty($CFG_GLPI["proxy_name"]) ? ($CFG_GLPI["proxy_name"] . ":" . $CFG_GLPI["proxy_port"]) : false; // host:port
       $proxy_ident = !empty($CFG_GLPI["proxy_user"]) ? ($CFG_GLPI["proxy_user"] . ":" .
-                                                        Toolbox::decrypt($CFG_GLPI["proxy_passwd"], GLPIKEY)) : false; // username:password
+                                                        (new GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"])) : false; // username:password
 
       $url = $options["url"];
 


### PR DESCRIPTION
`Toolbox::decrypt` was replaced with `Toolbox::sodiumDecrypt` in one of the 9.5 versions, and then that was deprecated in favor of methods in a `GLPIKey` class in GLPI 10.
This PR replaces the decrypt method call with the newest available method of decrypting data.