### PR TITLE
Do not define hooks if plugin is not active

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -42,7 +42,7 @@ function plugin_init_manufacturersimports() {
    $PLUGIN_HOOKS['csrf_compliant']['manufacturersimports'] = true;
 
    $plugin = new Plugin();
-   if ($plugin->isInstalled('manufacturersimports')
+   if ($plugin->isActivated('manufacturersimports')
        && Session::getLoginUserID()) {
       Plugin::registerClass('PluginManufacturersimportsProfile',
                             ['addtabon' => 'Profile']);


### PR DESCRIPTION
When the GLPI plugin page is displayed, `manufacturersimports` plugin hooks are defined if plugin is installed, even if it is not active.