### PR TITLE
Modification parsing date début/fin de garantie wortmann_ag

### DIFF
--- a/inc/wortmann_ag.class.php
+++ b/inc/wortmann_ag.class.php
@@ -71,9 +71,9 @@ class PluginManufacturersimportsWortmann_ag extends PluginManufacturersimportsMa
      */
     public function getBuyDate($contents)
     {
-        $field     = "but de la garantie";
+        $field     = "but de la service";
         $searchstart = stristr($contents, $field);
-        $myDate = substr($searchstart, 27, 10);
+        $myDate = substr($searchstart, 26, 10);
 
         $myDate = trim($myDate);
         $myDate = str_replace('/', '-', $myDate);
@@ -101,9 +101,9 @@ class PluginManufacturersimportsWortmann_ag extends PluginManufacturersimportsMa
      */
     public function getExpirationDate($contents)
     {
-        $field     = "Fin de garantie";
+        $field     = "Fin de service";
         $searchstart = stristr($contents, $field);
-        $myDate = substr($searchstart, 24, 10);
+        $myDate = substr($searchstart, 23, 10);
 
         $myDate = trim($myDate);
         $myDate = str_replace('/', '-', $myDate);


### PR DESCRIPTION
Changement du champs de recherche sur le site de wortmann_ag, passage de 'garantie' à 'service' et modification de l'offset pour avoir la date complète pour les fonctions : getBuyDate() et getExpirationDate().

Changed the search field on the wortmann_ag site from 'garantie' to 'service' and modified the offset to give the full date for the getBuyDate() and getExpirationDate() functions.