### PR TITLE
Fix: Dell Warranty duration was not picking up the furthest date.

### DIFF
--- a/src/Dell.php
+++ b/src/Dell.php
@@ -172,7 +172,7 @@ class Dell extends Manufacturer
             foreach ($info[0]['entitlements'] as $d) {
                 if ($d['endDate']) {
                     $date = new \DateTime($d['endDate']);
-                    if ($max_date == false || $date < $max_date) {
+                    if ($max_date == false || $date > $max_date) {
                         $max_date = $date;
                     }
                 }
@@ -202,7 +202,7 @@ class Dell extends Manufacturer
             foreach ($info[0]['entitlements'] as $k => $d) {
                 if ($d['endDate']) {
                     $date = new \DateTime($d['endDate']);
-                    if ($max_date == false || $date < $max_date) {
+                    if ($max_date == false || $date > $max_date) {
                         $max_date = $date;
                         $i = $k;
                     }


### PR DESCRIPTION
Currently, the Dell import always just get the earliest warranty expiration, so the base 1 year. This fixes it and can now pick-up the warranty extensions.