### PR TITLE
Fix expiration date logic to use latest entitlement end date

### DIFF
--- a/src/Dell.php
+++ b/src/Dell.php
@@ -172,7 +172,7 @@ class Dell extends Manufacturer
             foreach ($info[0]['entitlements'] as $d) {
                 if ($d['endDate']) {
                     $date = new \DateTime($d['endDate']);
-                    if ($max_date == false || $date < $max_date) {
+                    if ($max_date == false || $date > $max_date) {
                         $max_date = $date;
                     }
                 }
@@ -202,7 +202,7 @@ class Dell extends Manufacturer
             foreach ($info[0]['entitlements'] as $k => $d) {
                 if ($d['endDate']) {
                     $date = new \DateTime($d['endDate']);
-                    if ($max_date == false || $date < $max_date) {
+                    if ($max_date == false || $date > $max_date) {
                         $max_date = $date;
                         $i = $k;
                     }


### PR DESCRIPTION
A device can have **multiple entitlements**, each with its own `endDate`.
When determining the expiration date, we need to return the **latest (maximum) end date**, since that represents the actual final expiration of coverage.

However, using:

```php
$date < $max_date
```

selects the **earliest (minimum) date**, which results in:

* Returning the first entitlement that expires
* Incorrectly reporting an earlier expiration date
* Potentially shortening the displayed warranty/coverage period

### ✅ Correct Logic

To properly determine the expiration date, we must keep the comparison as:

```php
if ($max_date == false || $date > $max_date) {
    $max_date = $date;
}
```

This ensures that:

* On the first iteration, `$max_date` is initialized.
* On subsequent iterations, we keep the **latest (maximum) endDate**.
* The final result reflects the true expiration of all entitlements.